### PR TITLE
Allow legacy unicast clients according to rfc6762#section-6.7

### DIFF
--- a/lib/zeroconf/client.rb
+++ b/lib/zeroconf/client.rb
@@ -14,7 +14,7 @@ module ZeroConf
     end
 
     def run timeout: 3
-      sockets = open_interfaces interfaces.map(&:addr), 0
+      sockets = open_interfaces interfaces.map(&:addr), Resolv::MDNS::Port
 
       query = get_query
       sockets.each { |socket| multicast_send(socket, query.encode) }

--- a/lib/zeroconf/service.rb
+++ b/lib/zeroconf/service.rb
@@ -133,25 +133,25 @@ module ZeroConf
               break if has_flags
 
               if unicast
-                dnssd_unicast_answer(reply_id)
+                dnssd_unicast_answer(id: reply_id, legacy: legacy)
               else
                 dnssd_multicast_answer
               end
             when service
               if unicast
-                service_unicast_answer(reply_id)
+                service_unicast_answer(id: reply_id, legacy: legacy)
               else
                 service_multicast_answer
               end
             when service_name
               if unicast
-                service_instance_unicast_answer(reply_id)
+                service_instance_unicast_answer(id: reply_id, legacy: legacy)
               else
                 service_instance_multicast_answer
               end
             when qualified_host
               if unicast
-                name_answer_unicast(reply_id)
+                name_answer_unicast(id: reply_id, legacy: legacy)
               else
                 name_answer_multicast
               end
@@ -178,7 +178,7 @@ module ZeroConf
 
     private
 
-    def service_instance_unicast_answer(id)
+    def service_instance_unicast_answer(id:, legacy:)
       msg = Resolv::DNS::Message.new(0)
       msg.qr = 1
       msg.aa = 1
@@ -202,12 +202,12 @@ module ZeroConf
           Resolv::DNS::Resource::IN::TXT.new(*@text)
       end
       msg.add_answer service_name, 10, Resolv::DNS::Resource::IN::SRV.new(0, 0, service_port, qualified_host)
-      msg.add_question service_name, MDNS::Announce::IN::SRV
+      msg.add_question service_name, legacy ? Resolv::DNS::Resource::IN::SRV : MDNS::Announce::IN::SRV
 
       msg
     end
 
-    def service_unicast_answer(id)
+    def service_unicast_answer(id:, legacy:)
       msg = Resolv::DNS::Message.new(0)
       msg.qr = 1
       msg.aa = 1
@@ -237,12 +237,12 @@ module ZeroConf
         10,
         Resolv::DNS::Resource::IN::PTR.new(Resolv::DNS::Name.create(service_name))
 
-      msg.add_question service, PTR
+      msg.add_question service, legacy ? Resolv::DNS::Resource::IN::PTR : PTR
 
       msg
     end
 
-    def dnssd_unicast_answer(id)
+    def dnssd_unicast_answer(id:, legacy:)
       msg = Resolv::DNS::Message.new(0)
       msg.qr = 1
       msg.aa = 1
@@ -251,7 +251,7 @@ module ZeroConf
       msg.add_answer DISCOVERY_NAME, 10,
         Resolv::DNS::Resource::IN::PTR.new(Resolv::DNS::Name.create(service))
 
-      msg.add_question DISCOVERY_NAME, PTR
+      msg.add_question DISCOVERY_NAME, legacy ? Resolv::DNS::Resource::IN::PTR : PTR
       msg
     end
 
@@ -325,7 +325,7 @@ module ZeroConf
       msg
     end
 
-    def name_answer_unicast(id)
+    def name_answer_unicast(id:, legacy:)
       msg = Resolv::DNS::Message.new(0)
       msg.qr = 1
       msg.aa = 1
@@ -358,7 +358,7 @@ module ZeroConf
         end
       end
 
-      msg.add_question qualified_host, MDNS::Announce::IN::A
+      msg.add_question qualified_host, legacy ? Resolv::DNS::Resource::IN::A : MDNS::Announce::IN::A
 
       if @text
         msg.add_additional service_name,

--- a/lib/zeroconf/utils.rb
+++ b/lib/zeroconf/utils.rb
@@ -4,6 +4,7 @@ require "socket"
 require "ipaddr"
 require "fcntl"
 require "resolv"
+require "rbconfig"
 
 module ZeroConf
   MDNS_CACHE_FLUSH = 0x8000
@@ -57,7 +58,7 @@ module ZeroConf
     def open_ipv4 saddr, port
       sock = UDPSocket.new Socket::AF_INET
       sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
-      sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEPORT, true)
+      sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEPORT, true) unless RbConfig::CONFIG["host_os"].include?("linux")
       sock.setsockopt(Socket::IPPROTO_IP, Socket::IP_MULTICAST_TTL, true)
       sock.setsockopt(Socket::IPPROTO_IP, Socket::IP_MULTICAST_LOOP, true)
       sock.setsockopt(Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP,
@@ -97,7 +98,7 @@ module ZeroConf
     def open_ipv6 saddr, port
       sock = UDPSocket.new Socket::AF_INET6
       sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
-      sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEPORT, true)
+      sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEPORT, true) unless RbConfig::CONFIG["host_os"].include?("linux")
       sock.setsockopt(Socket::IPPROTO_IPV6, Socket::IPV6_MULTICAST_HOPS, true)
       sock.setsockopt(Socket::IPPROTO_IPV6, Socket::IPV6_MULTICAST_LOOP, true)
 

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -34,7 +34,7 @@ module ZeroConf
       query = Resolv::DNS::Message.new 0
       query.add_question "tc-lan-adapter._test-mdns._tcp.local.", SRV
 
-      sock = open_ipv4 iface.addr, 0
+      sock = open_ipv4 iface.addr, Resolv::MDNS::Port
       multicast_send sock, query.encode
       res = Resolv::DNS::Message.decode read_with_timeout(sock).first
       s.stop
@@ -68,7 +68,7 @@ module ZeroConf
 
       query = Resolv::DNS::Message.new 0
       query.add_question "_services._dns-sd._udp.local.", Resolv::DNS::Resource::IN::PTR
-      sock = open_ipv4 iface.addr, 0
+      sock = open_ipv4 iface.addr, Resolv::MDNS::Port
       multicast_send sock, query.encode
 
       while res = q.pop
@@ -172,7 +172,7 @@ module ZeroConf
       query = Resolv::DNS::Message.new 0
       query.add_question "_services._dns-sd._udp.local.", PTR
 
-      sock = open_ipv4 iface.addr, 0
+      sock = open_ipv4 iface.addr, Resolv::MDNS::Port
       multicast_send sock, query.encode
 
       res = nil
@@ -210,7 +210,7 @@ module ZeroConf
 
       query = Resolv::DNS::Message.new 0
       query.add_question "_test-mdns._tcp.local.", Resolv::DNS::Resource::IN::PTR
-      sock = open_ipv4 iface.addr, 0
+      sock = open_ipv4 iface.addr, Resolv::MDNS::Port
       multicast_send sock, query.encode
 
       service = Resolv::DNS::Name.create s.service
@@ -257,7 +257,7 @@ module ZeroConf
       query = Resolv::DNS::Message.new 0
       query.add_question "_test-mdns._tcp.local.", PTR
 
-      sock = open_ipv4 iface.addr, 0
+      sock = open_ipv4 iface.addr, Resolv::MDNS::Port
       multicast_send sock, query.encode
       res = Resolv::DNS::Message.decode read_with_timeout(sock).first
       s.stop
@@ -294,7 +294,7 @@ module ZeroConf
 
       query = Resolv::DNS::Message.new 0
       query.add_question "tc-lan-adapter._test-mdns._tcp.local.", Resolv::DNS::Resource::IN::PTR
-      sock = open_ipv4 iface.addr, 0
+      sock = open_ipv4 iface.addr, Resolv::MDNS::Port
       multicast_send sock, query.encode
 
       service_name = Resolv::DNS::Name.create s.service_name
@@ -336,7 +336,7 @@ module ZeroConf
       query = Resolv::DNS::Message.new 0
       query.add_question "tc-lan-adapter.local.", A
 
-      sock = open_ipv4 iface.addr, 0
+      sock = open_ipv4 iface.addr, Resolv::MDNS::Port
       multicast_send sock, query.encode
       res = Resolv::DNS::Message.decode read_with_timeout(sock).first
       s.stop
@@ -369,7 +369,7 @@ module ZeroConf
 
       query = Resolv::DNS::Message.new 0
       query.add_question "tc-lan-adapter.local.", Resolv::DNS::Resource::IN::A
-      sock = open_ipv4 iface.addr, 0
+      sock = open_ipv4 iface.addr, Resolv::MDNS::Port
       multicast_send sock, query.encode
 
       host = Resolv::DNS::Name.create s.qualified_host


### PR DESCRIPTION
Unicast responses already follow https://datatracker.ietf.org/doc/html/rfc6762#section-6.7. 

The only thing missing is supplying the right id for the answer (0 for multicast, id of query for legacy unicast). 
Other than that unicast is only triggered with the unicast bit, instead of also supporting legacy clients. 
This adds detection of legacy clients according to the spec.