### PR TITLE
Allow Server to ignore malformed requests

### DIFF
--- a/lib/zeroconf.rb
+++ b/lib/zeroconf.rb
@@ -67,8 +67,8 @@ module ZeroConf
     resolver.run(timeout:, &blk)
   end
 
-  def self.service service, service_port, hostname = Socket.gethostname, service_interfaces: self.service_interfaces, text: [""]
-    s = Service.new(service, service_port, hostname, service_interfaces:, text:)
+  def self.service service, service_port, hostname = Socket.gethostname, service_interfaces: self.service_interfaces, text: [""], ignore_malformed_requests: false
+    s = Service.new(service, service_port, hostname, service_interfaces:, text:, ignore_malformed_requests:)
     s.start
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -39,11 +39,12 @@ module ZeroConf
       Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
     end
 
-    def make_server iface, host = HOST_NAME
+    def make_server iface, host = HOST_NAME, **opts
       Service.new SERVICE + ".",
         42424,
         host,
-        service_interfaces: [iface], text: ["test=1", "other=value"]
+        service_interfaces: [iface], text: ["test=1", "other=value"],
+        **opts
     end
 
     def make_listener rd, q

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -529,6 +529,17 @@ module ZeroConf
       assert_equal expected, res
     end
 
+    def test_ignore_malformed_requests
+      s = make_server iface, ignore_malformed_requests: true
+      runner = Thread.new { s.start }
+      Thread.pass until s.started?
+
+      sock = open_ipv4 iface.addr, Resolv::MDNS::Port
+      multicast_send sock, "not a valid DNS message"
+      s.stop
+      runner.join
+    end
+
     def read_with_timeout sock
       return unless sock.wait_readable(3)
       sock.recvfrom(2048)


### PR DESCRIPTION
While running the Service on my network, it will crash when it receives a certain message from something involving my oculus attached to my gaming pc. As a result, the call to `Resolv::DNS::Message.decode` raises an error and the server shuts down. Then I am sad.

Is the incoming request valid and there's an issue with the Resolv's decode? Is the incoming request invalid? Is the incoming request an attempt to infiltrate my computer so that FB can know more about what kind of dog blankets I might buy? Is it a subtly genius optimization hand-coded by Carmack himself in order to save a few cycles on some VR shader optimization? Who can say? (...as someone who learned about mDns on Tuesday: not me.)

Perhaps rescue and warn might be a nice default behavior, but I didn't want to be the first to spam stdout/stderr, so I made it a flag.