### PR TITLE
Allow instance name to be set explicitly

### DIFF
--- a/lib/zeroconf/service.rb
+++ b/lib/zeroconf/service.rb
@@ -9,14 +9,21 @@ module ZeroConf
     attr_reader :service, :service_port, :hostname, :service_interfaces,
       :service_name, :qualified_host, :text, :abort_on_malformed_requests
 
-    def initialize service, service_port, hostname = Socket.gethostname, service_interfaces: ZeroConf.service_interfaces, text: [""], abort_on_malformed_requests: false, started_callback: nil
+    def initialize service, service_port, hostname = Socket.gethostname, service_interfaces: ZeroConf.service_interfaces, instance_name: nil, text: [""], abort_on_malformed_requests: false, started_callback: nil
       @service = service
       @service_port = service_port
-      @hostname = hostname
+
+      @hostname = strip_dot_local(hostname) # We re-add .local anyway, later on
       @service_interfaces = service_interfaces
       @abort_on_malformed_requests = abort_on_malformed_requests
-      @service_name = "#{hostname}.#{service}"
-      @qualified_host = "#{hostname}.local."
+
+      instance_name ||= @hostname
+      if instance_name.include?(".")
+        raise ArgumentError, "instance_name must not contain dots (is #{instance_name.inspect})" 
+      end
+
+      @service_name = "#{instance_name}.#{@service}"
+      @qualified_host = "#{@hostname}.local."
       @started_callback = started_callback
       @text = text
       @started = false

--- a/lib/zeroconf/utils.rb
+++ b/lib/zeroconf/utils.rb
@@ -94,6 +94,10 @@ module ZeroConf
       sock.send(data, 0, Addrinfo.new(to))
     end
 
+    def strip_dot_local(from_string)
+      from_string.to_s.gsub(/\.local\.?$/, "")
+    end
+
     def open_ipv6 saddr, port
       sock = UDPSocket.new Socket::AF_INET6
       sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)


### PR DESCRIPTION
and ensure it does not contain dots. "Instance name" is the terminology used by some mDNS browsers, it is basically the service name sans the service component.

The service name may include all sorts of characters except for the separator (the dot), and it may include spaces. If one wants to expose a service on a .local subdomain (for example - for Rails testing) - deriving the service name from the hostname _may_ work, but it is easier to make it settable explicitly. Devices like printers do that as well. If you try to advertize a service with dots in it, it will be considered a "different type of service" and in my experience such records just don't end up getting honored.

Another option would be to replace all dots in the service name before the service type with, say, dashes - that would be more automatic, but it is neat that the service name can be "art-directed".

Remove the .local component from the passed hostname, because it seems redundant - we only advertise the fully-qualified hostname, to which we append .local. anyway.